### PR TITLE
Fix scipy binom_test deprecation

### DIFF
--- a/ranky/duel.py
+++ b/ranky/duel.py
@@ -8,7 +8,7 @@
 # TODO: clarify names, add scored version of NHST and more.
 
 import numpy as np
-from scipy.stats import binom_test
+from scipy.stats import binomtest
 from baycomp import two_on_single, two_on_multiple
 
 def declare_ties(a, b, comparison_func=None, **kwargs):
@@ -76,7 +76,7 @@ def p_wins(a, b, pval=0.05, reverse=False):
     Wa, Wb = np.sum(a > b), np.sum(b > a)
     if reverse:
         Wa, Wb = np.sum(a < b), np.sum(b < a)
-    significant = binom_test(Wa, n=len(a), p=0.5) <= pval
+    significant = binomtest(Wa, n=len(a), p=0.5).pvalue <= pval
     wins = Wa > Wb
     return significant and wins # count only significant wins
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 pandas
 numpy
 matplotlib
-scikit-learn==0.23.2
-scipy
+scikit-learn>=1.0
+scipy>=1.7.0
 seaborn
 networkx
 python-Levenshtein

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
          "Operating System :: Unix",
      ],
      install_requires=[
-        'pandas', 'numpy', 'matplotlib', 'scikit-learn>=0.23.2', 
-        'scipy', 'seaborn', 'networkx', 'python-Levenshtein', 'tqdm', 'baycomp',
+        'pandas', 'numpy', 'matplotlib', 'scikit-learn>=1.0', 
+        'scipy>=1.7.0', 'seaborn', 'networkx', 'python-Levenshtein', 'tqdm', 'baycomp',
      ],
  )


### PR DESCRIPTION
Hi @Didayolo,

I've updated Ranky to replace the deprecated binom_test with binomtest, as recommended in SciPy version 1.10.0 and required from 1.12.0. You can see the details here: [binom_test](https://docs.scipy.org/doc/scipy-1.11.4/reference/generated/scipy.stats.binom_test.html#scipy.stats.binom_test) and [binomtest](https://docs.scipy.org/doc/scipy-1.11.4/reference/generated/scipy.stats.binomtest.html#scipy.stats.binomtest).

I also upgraded SciPy to at least version 1.7.0 and scikit-learn to at least version 1.0 to ensure compatibility with binomtest and modern Python versions, changed in both setup.py and requirement.txt. I try locally and unit_test.py is passing.

Best,
Arthur